### PR TITLE
fix windows NODE_ENV” is not recognized

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "nodemon": "^1.18.3",
     "prettier": "^1.15.2",
     "rimraf": "^2.6.2",
-    "supertest": "^3.3.0"
+    "supertest": "^3.3.0",
+    "win-node-env": "^0.4.0"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
I can't able to run test command bcoz “NODE_ENV” is not recognized as an internal or external command.
so I solve this issue by installing  `win-node-env` that  Creates executables like NODE_ENV.cmd that sets the NODE_ENV environment variable and runs the rest of the command.