### PR TITLE
Update item.router.js

### DIFF
--- a/src/resources/item/item.router.js
+++ b/src/resources/item/item.router.js
@@ -6,7 +6,7 @@ const router = Router()
 // /api/item
 router
   .route('/')
-  .get(controllers.getOne)
+  .get(controllers.getMany)
   .post(controllers.createOne)
 
 // /api/item/:id


### PR DESCRIPTION
Root path on /api/item uses the getMany controller instead of getOne.