### PR TITLE
Add extra connect() options to remove deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "verbose": true,
     "testURL": "http://localhost/",
     "testEnvironment": "node",
-    "setupTestFrameworkScriptFile": "<rootDir>/test-db-setup.js",
+    "setupFilesAfterEnv": [
+      "<rootDir>/test-db-setup.js"
+    ],
     "testPathIgnorePatterns": [
       "dist/"
     ],

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -2,8 +2,10 @@ import mongoose from 'mongoose'
 import options from '../config'
 
 export const connect = (url = options.dbUrl, opts = {}) => {
-  return mongoose.connect(
-    url,
-    { ...opts, useNewUrlParser: true }
-  )
+  return mongoose.connect(url, {
+    ...opts,
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+    useCreateIndex: true,
+  })
 }

--- a/test-db-setup.js
+++ b/test-db-setup.js
@@ -18,7 +18,7 @@ global.newId = () => {
 
 const remove = collection =>
   new Promise((resolve, reject) => {
-    collection.remove(err => {
+    collection.deleteMany(err => {
       if (err) return reject(err)
       resolve()
     })
@@ -36,7 +36,9 @@ beforeEach(async done => {
         url + db,
         {
           useNewUrlParser: true,
-          autoIndex: true
+          autoIndex: true,
+          useUnifiedTopology: true,
+          useCreateIndex: true,
         }
       )
       await clearDB()


### PR DESCRIPTION
With the latest`mongoose@5.x` and `mongodb@4.x`, I got the following deprecation warnings

<img width="657" alt="image" src="https://user-images.githubusercontent.com/6238558/90409991-bd639d00-e0a1-11ea-9f03-7c53f6132bc2.png">

Updating the connect method options removed the warnings for me

Also: https://mongoosejs.com/docs/deprecations.html