### PR TITLE
Fix for List validation error while Create a Item & Route Fix.

### DIFF
--- a/src/resources/item/item.model.js
+++ b/src/resources/item/item.model.js
@@ -23,8 +23,7 @@ const itemSchema = new mongoose.Schema(
     },
     list: {
       type: mongoose.SchemaTypes.ObjectId,
-      ref: 'list',
-      required: true
+      ref: 'list'
     }
   },
   { timestamps: true }

--- a/src/resources/item/item.router.js
+++ b/src/resources/item/item.router.js
@@ -6,7 +6,7 @@ const router = Router()
 // /api/item
 router
   .route('/')
-  .get(controllers.getOne)
+  .get(controllers.getMany)
   .post(controllers.createOne)
 
 // /api/item/:id

--- a/src/resources/list/list.router.js
+++ b/src/resources/list/list.router.js
@@ -6,7 +6,7 @@ const router = Router()
 // /api/list
 router
   .route('/')
-  .get(controllers.getOne)
+  .get(controllers.getMany)
   .post(controllers.createOne)
 
 // /api/list/:id


### PR DESCRIPTION
- Error message: "item validation failed: list: Path `list` is required."
- It would be getMany instead of getOne on route get /api/item & list